### PR TITLE
Make PcapPlusPlus compile with YANET's compile options:

### DIFF
--- a/3rdParty/LightPcapNg/LightPcapNg/include/light_pcapng.h
+++ b/3rdParty/LightPcapNg/LightPcapNg/include/light_pcapng.h
@@ -107,7 +107,7 @@ void light_pcapng_historgram(const light_pcapng pcapng, uint32_t (*key_master)(c
 int light_get_block_info(const light_pcapng pcapng, light_info info_flag, void *info_data, size_t *data_size);
 light_option light_get_option(const light_pcapng pcapng, uint16_t option_code);
 uint16_t light_get_option_code(const light_option option);
-const light_option light_get_next_option(const light_option option);
+light_option light_get_next_option(const light_option option);
 uint32_t *light_get_option_data(const light_option option);
 uint16_t light_get_option_length(const light_option option);
 

--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_io.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_io.c
@@ -115,8 +115,8 @@ light_pcapng light_read_stream(light_pcapng_stream pcapng)
 	}
 
 	// PCPP patch
-	if (light_read(pcapng->file, &block_type, sizeof(block_type)) == -1 ||
-			light_read(pcapng->file, &block_total_length, sizeof(block_total_length)) == -1) {
+	if (light_read(pcapng->file, &block_type, sizeof(block_type)) == (size_t)-1 ||
+			light_read(pcapng->file, &block_total_length, sizeof(block_total_length)) == (size_t)-1) {
 		pcapng->valid = 0;
 		return NULL;
 	}
@@ -131,7 +131,7 @@ light_pcapng light_read_stream(light_pcapng_stream pcapng)
 	block_data[1] = block_total_length;
 
 	// PCPP patch
-	if (light_read(pcapng->file, &block_data[2], block_total_length - 2 * sizeof(uint32_t)) == -1) {
+	if (light_read(pcapng->file, &block_data[2], block_total_length - 2 * sizeof(uint32_t)) == (size_t)-1) {
 		free(block_data);
 		pcapng->valid = 0;
 		return NULL;

--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_option.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_option.c
@@ -49,7 +49,7 @@ uint16_t light_get_option_code(const light_option option)
 	return option->custom_option_code;
 }
 
-const light_option light_get_next_option(const light_option option)
+light_option light_get_next_option(const light_option option)
 {
 	return option->next_option;
 }

--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng.c
@@ -303,7 +303,7 @@ void light_read_record(light_file fd, light_pcapng *record)
    //See the block type, if end of file this will tell us
    uint32_t blockType, blockSize, bytesRead;
    bytesRead = light_read(fd, &blockType, sizeof(blockType));
-   if (bytesRead != sizeof(blockType) || (bytesRead == EOF && feof(fd->file)))
+   if (bytesRead != sizeof(blockType) || (bytesRead == (uint32_t)EOF && feof(fd->file)))
    {
       current = NULL;
       return;
@@ -318,7 +318,7 @@ void light_read_record(light_file fd, light_pcapng *record)
 
    //Get block size
    bytesRead = light_read(fd, &current->block_total_length, sizeof(blockSize));
-   if (bytesRead != sizeof(blockSize) || (bytesRead == EOF && feof(fd->file)))
+   if (bytesRead != sizeof(blockSize) || (bytesRead == (uint32_t)EOF && feof(fd->file)))
    {
       free(current);
       current = NULL;
@@ -332,7 +332,7 @@ void light_read_record(light_file fd, light_pcapng *record)
    const uint32_t bytesToRead = current->block_total_length - 2 * sizeof(blockSize) - sizeof(blockType);
    uint32_t *local_data = calloc(bytesToRead, 1);
    bytesRead = light_read(fd, local_data, bytesToRead);
-   if (bytesRead != bytesToRead || (bytesRead == EOF && feof(fd->file)))
+   if (bytesRead != bytesToRead || (bytesRead == (uint32_t)EOF && feof(fd->file)))
    {
       free(current);
       free(local_data);
@@ -343,7 +343,7 @@ void light_read_record(light_file fd, light_pcapng *record)
    //Need to move file to next record so read the footer, which is just the record length repeated
    bytesRead = light_read(fd, &blockSize, sizeof(blockSize));
    //Verify the two sizes match!!
-   if (blockSize != current->block_total_length || bytesRead != sizeof(blockSize) || (bytesRead == EOF && feof(fd->file)))
+   if (blockSize != current->block_total_length || bytesRead != sizeof(blockSize) || (bytesRead == (uint32_t)EOF && feof(fd->file)))
    {
       free(current);
       free(local_data);

--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
@@ -269,7 +269,7 @@ light_pcapng_t *light_pcapng_open_write(const char* file_path, light_pcapng_file
 	}
 
 	light_pcapng next_block = blocks_to_write;
-	int i = 0;
+	size_t i = 0;
 	for (i = 0; i < file_info->interface_block_count; i++)
 	{
 		struct _light_interface_description_block interface_block;

--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_platform.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_platform.c
@@ -142,7 +142,7 @@ size_t light_read(light_file fd, void *buf, size_t count)
 	if (fd->decompression_context == NULL)
 	{
 		size_t bytes_read = fread(buf, 1, count, fd->file);
-		return  bytes_read != count ? -1 : bytes_read;
+		return  bytes_read != count ? (size_t)-1 : bytes_read;
 	}
 	else
 	{
@@ -155,7 +155,7 @@ size_t light_write(light_file fd, const void *buf, size_t count)
 	if (fd->compression_context == NULL)
 	{
 		size_t bytes_written = fwrite(buf, 1, count, fd->file);
-		return  bytes_written != count ? -1 : bytes_written;
+		return  bytes_written != count ? (size_t)-1 : bytes_written;
 	}
 	else
 	{

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -660,6 +660,7 @@ namespace pcpp
 		///  - IP_ADDRESS/NETMASK where IP_ADDRESS is a valid IP address representing the network prefix and NETMASK
 		///    is a valid netmask for this type of network (IPv4 or IPv6 network)
 		/// @throws std::invalid_argument The provided string does not represent a valid address and netmask format.
+#if defined(__cpp_exceptions)
 		IPNetwork(const std::string& addressAndNetmask)
 		{
 			try
@@ -671,6 +672,7 @@ namespace pcpp
 				m_IPv6Network = std::unique_ptr<IPv6Network>(new IPv6Network(addressAndNetmask));
 			}
 		}
+#endif
 
 		/// A copy c'tor for this class
 		/// @param other The instance to copy from

--- a/Common++/header/MacAddress.h
+++ b/Common++/header/MacAddress.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdlib>
 #include <initializer_list>
 #include <iterator>
 #include <ostream>
@@ -71,7 +72,11 @@ namespace pcpp
 		{
 			if (octets.size() != sizeof(m_Address))
 			{
+#if defined(__cpp_exceptions)
 				throw std::invalid_argument("Invalid initializer list size, should be 6");
+#else
+				std::abort();
+#endif
 			}
 			std::copy(octets.begin(), octets.end(), std::begin(m_Address));
 		}
@@ -100,7 +105,11 @@ namespace pcpp
 		{
 			if (octets.size() != sizeof(m_Address))
 			{
+#if defined(__cpp_exceptions)
 				throw std::invalid_argument("Invalid initializer list size, should be 6");
+#else
+				std::abort();
+#endif
 			}
 
 			std::copy(octets.begin(), octets.end(), std::begin(m_Address));

--- a/Pcap++/src/MBufRawPacket.cpp
+++ b/Pcap++/src/MBufRawPacket.cpp
@@ -109,7 +109,7 @@ namespace pcpp
 	}
 #endif
 
-	MBufRawPacket::MBufRawPacket(const MBufRawPacket& other)
+	MBufRawPacket::MBufRawPacket(const MBufRawPacket& other) : RawPacket()
 	{
 		m_DeleteRawDataAtDestructor = false;
 		m_MBuf = nullptr;


### PR DESCRIPTION
- Avoid type qualifiers being ignored on function return type [-Werror=ignored-qualifiers]
- Avoid comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
- Fix comparison is always true due to limited range of data type [-Werror=type-limits]
- Compile out some constuctors from header files as those were using excepctions, and we have them disabled in dataplane