### PR TITLE
Remove dependency on CMake 3.12 Features

### DIFF
--- a/3rdParty/hash-library/CMakeLists.txt
+++ b/3rdParty/hash-library/CMakeLists.txt
@@ -1,12 +1,14 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(hash-library LANGUAGES CXX)
 
-add_library(hash-library OBJECT ./md5.cpp)
+# Create an object library
+add_library(hash-library-obj OBJECT ./md5.cpp)
 
-target_include_directories(hash-library PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/)
-target_link_libraries(hash-library PRIVATE EndianPortable)
+# Include directories for the object library, including EndianPortable's includes
+target_include_directories(hash-library-obj PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  $<TARGET_PROPERTY:EndianPortable,INTERFACE_INCLUDE_DIRECTORIES>
+)
 
-if(BUILD_SHARED_LIBS)
-  set_property(TARGET hash-library PROPERTY POSITION_INDEPENDENT_CODE ON)
-endif()
+# No 'target_link_libraries' call for object libraries as they can't link directly

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # We need 3.12 or later, so that we can set policy CMP0074; see below.
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(PCAPPP_VERSION "24.09+")
 
@@ -9,11 +9,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(PCAPPP_MAIN_PROJECT ON)
 endif()
 
-project(
-  PcapPlusPlus
-  DESCRIPTION "PcapPlusPlus is a multiplatform C++ library for capturing, parsing and crafting of network packets."
-  LANGUAGES CXX
-  HOMEPAGE_URL "https://pcapplusplus.github.io/")
+project(PcapPlusPlus CXX)
 
 # Include our custom CMake modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
@@ -218,8 +214,10 @@ if(Git_FOUND)
     OUTPUT_VARIABLE PCAPPP_GIT_BRANCH)
   string(STRIP "${PCAPPP_GIT_BRANCH}" PCAPPP_GIT_BRANCH)
   message(STATUS "Building from commit:${PCAPPP_GIT_COMMIT} on branch:${PCAPPP_GIT_BRANCH}")
-  add_compile_definitions(GIT_COMMIT="${PCAPPP_GIT_COMMIT}")
-  add_compile_definitions(GIT_BRANCH="${PCAPPP_GIT_BRANCH}")
+  # Use add_definitions instead of add_compile_definitions
+  # -D is required since add_definitions works with raw flags:
+  add_definitions("-DGIT_COMMIT=\"${PCAPPP_GIT_COMMIT}\"")
+  add_definitions("-DGIT_BRANCH=\"${PCAPPP_GIT_BRANCH}\"")
 endif()
 
 if(PCAPPP_USE_PF_RING)

--- a/Packet++/CMakeLists.txt
+++ b/Packet++/CMakeLists.txt
@@ -1,6 +1,8 @@
+cmake_minimum_required(VERSION 3.10)
+
 add_library(
   Packet++
-  $<TARGET_OBJECTS:hash-library>
+  $<TARGET_OBJECTS:hash-library-obj>
   src/ArpLayer.cpp
   src/Asn1Codec.cpp
   src/BgpLayer.cpp
@@ -143,11 +145,11 @@ set_property(TARGET Packet++ PROPERTY PUBLIC_HEADER ${public_headers})
 target_include_directories(
   Packet++
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/header> $<INSTALL_INTERFACE:include/pcapplusplus>
-  # Don't link with hash-library nor EndianPortable as they won't be exported
-  PRIVATE $<TARGET_PROPERTY:hash-library,INCLUDE_DIRECTORIES>
+  # Use the includes from `hash-library-obj` and `EndianPortable`
+  PRIVATE $<TARGET_PROPERTY:hash-library-obj,INCLUDE_DIRECTORIES>
   PRIVATE $<TARGET_PROPERTY:EndianPortable,INTERFACE_INCLUDE_DIRECTORIES>)
 
-target_link_libraries(Packet++ PUBLIC Common++)
+target_link_libraries(Packet++ PUBLIC Common++ EndianPortable)
 
 if(PCAPPP_INSTALL)
   install(


### PR DESCRIPTION
We need compatibility with Ubuntu 18.04 which ships with CMake 3.10.3.

1. CMake 3.10 does not support add_compile_definitions()
Use add_definitions() to add preprocessor flags directly to the compile line

2. CMake 3.10 does not support DESCRIPTION and HOMEPAGE_URL in the project()
Remove them

3. Cmake 3.10 does not support calling target_link_libraries() for object libraries.
Initially, hash-library was defined as an object library that attempted to link directly against EndianPortable. This won't work under CMake 3.10 because object libraries aren't permitted to link against other targets. So I create an object library hash-library-obj only to compile the source files (md5.cpp) into object files, with no linkage to EndianPortable. Then in Packet++, where those libraries are actually used I specify EndianPortable directly.